### PR TITLE
[build] use bin and lib as output directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,10 @@ endif()
 
 set(OT_PLATFORM_LIB "openthread-${NRF_PLATFORM}" "openthread-${NRF_PLATFORM}-transport")
 
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
+
 add_subdirectory(openthread)
 
 target_compile_definitions(ot-config INTERFACE

--- a/src/nrf52811/README.md
+++ b/src/nrf52811/README.md
@@ -66,11 +66,11 @@ $ cd <path-to-ot-nrf528xx>
 $ ./script/build nrf52811 UART_trans
 ```
 
-After a successful build, the `elf` files can be found in `<path-to-ot-nrf528xx>/build/openthread/examples/apps/*`. You can convert them to hex using `arm-none-eabi-objcopy`:
+After a successful build, the `elf` files can be found in `<path-to-ot-nrf528xx>/build/bin/*`. You can convert them to hex using `arm-none-eabi-objcopy`:
 
 ```bash
-$ arm-none-eabi-objcopy -O ihex build/openthread/examples/apps/cli/ot-cli-mtd ot-cli-mtd.hex
-$ arm-none-eabi-objcopy -O ihex build/openthread/examples/apps/ncp/ot-rcp ot-rcp.hex
+$ arm-none-eabi-objcopy -O ihex build/bin/ot-cli-mtd ot-cli-mtd.hex
+$ arm-none-eabi-objcopy -O ihex build/bin/ot-rcp ot-rcp.hex
 
 ```
 

--- a/src/nrf52833/README.md
+++ b/src/nrf52833/README.md
@@ -39,10 +39,10 @@ $ cd <path-to-ot-nrf528xx>
 $ ./script/build nrf52833 UART_trans
 ```
 
-After a successful build, the `elf` files can be found in `<path-to-ot-nrf528xx>/build/openthread/examples/apps/*`. You can convert them to hex using `arm-none-eabi-objcopy`:
+After a successful build, the `elf` files can be found in `<path-to-ot-nrf528xx>/build/bin/*`. You can convert them to hex using `arm-none-eabi-objcopy`:
 
 ```bash
-$ arm-none-eabi-objcopy -O ihex build/openthread/examples/apps/cli/ot-cli-ftd ot-cli-ftd.hex
+$ arm-none-eabi-objcopy -O ihex build/bin/ot-cli-ftd ot-cli-ftd.hex
 ```
 
 ### USB CDC ACM support

--- a/src/nrf52840/README.md
+++ b/src/nrf52840/README.md
@@ -44,10 +44,10 @@ $ cd <path-to-ot-nrf528xx>
 $ ./script/build nrf52840 UART_trans
 ```
 
-After a successful build, the `elf` files can be found in `<path-to-ot-nrf528xx>/build/openthread/examples/apps/*`. You can convert them to hex using `arm-none-eabi-objcopy`:
+After a successful build, the `elf` files can be found in `<path-to-ot-nrf528xx>/build/bin/*`. You can convert them to hex using `arm-none-eabi-objcopy`:
 
 ```bash
-$ arm-none-eabi-objcopy -O ihex build/openthread/examples/apps/cli/ot-cli-ftd ot-cli-ftd.hex
+$ arm-none-eabi-objcopy -O ihex build/bin/ot-cli-ftd ot-cli-ftd.hex
 ```
 
 ### USB CDC ACM support


### PR DESCRIPTION
This PR makes binaries and libraries generated at specified directory in nrf cmake build. I think putting all the binaries and libraries in one directory would be better. 

[PR#6127](https://github.com/openthread/openthread/pull/6127) in openthread repo.