### PR TITLE
[uart] implement otPlatUartFlush()

### DIFF
--- a/src/src/transport/uart.c
+++ b/src/src/transport/uart.c
@@ -143,7 +143,11 @@ exit:
 
 otError otPlatUartFlush(void)
 {
-    return OT_ERROR_NOT_IMPLEMENTED;
+    while (sTransmitBuffer && !sTransmitDone)
+    {
+        // Wait until the transmission is done
+    }
+    return OT_ERROR_NONE;
 }
 
 /**


### PR DESCRIPTION
This PR is a proposition of a problem reported in https://github.com/openthread/openthread/issues/6623. Current CLI  implementation (UART variant) uses `otPlatUartFlush()` for corner case and crashes when it is not implemented. While it would be better to handle asynchronous transmissions in CLI I think that there is no strong reason to not implement this function.

Fixes https://github.com/openthread/openthread/issues/6623