### PR TITLE
[uart] add a cmake cache entry for specifying Baud rate

### DIFF
--- a/src/nrf52811/nrf52811.cmake
+++ b/src/nrf52811/nrf52811.cmake
@@ -57,6 +57,10 @@ if(OT_CFLAGS MATCHES "-pedantic-errors")
     string(REPLACE "-pedantic-errors" "" OT_CFLAGS "${OT_CFLAGS}")
 endif()
 
+set(OT_UART_BAUDRATE 115200 CACHE STRING "UART Baud rate. It must be a pre-defined
+value in src/nrf52811/transport-config.h")
+add_definitions(-DUART_BAUDRATE=NRF_UARTE_BAUDRATE_${OT_UART_BAUDRATE})
+
 add_library(openthread-nrf52811
     ${NRF_COMM_SOURCES}
     ${NRF_SINGLEPHY_SOURCES}

--- a/src/nrf52833/nrf52833.cmake
+++ b/src/nrf52833/nrf52833.cmake
@@ -65,6 +65,10 @@ if(OT_CFLAGS MATCHES "-pedantic-errors")
     string(REPLACE "-pedantic-errors" "" OT_CFLAGS "${OT_CFLAGS}")
 endif()
 
+set(OT_UART_BAUDRATE 115200 CACHE STRING "UART Baud rate. It must be a pre-defined
+value in src/nrf52833/transport-config.h")
+add_definitions(-DUART_BAUDRATE=NRF_UARTE_BAUDRATE_${OT_UART_BAUDRATE})
+
 add_library(openthread-nrf52833
     ${NRF_COMM_SOURCES}
     ${NRF_SINGLEPHY_SOURCES}

--- a/src/nrf52840/nrf52840.cmake
+++ b/src/nrf52840/nrf52840.cmake
@@ -76,6 +76,10 @@ if(OT_CFLAGS MATCHES "-pedantic-errors")
     string(REPLACE "-pedantic-errors" "" OT_CFLAGS "${OT_CFLAGS}")
 endif()
 
+set(OT_UART_BAUDRATE 115200 CACHE STRING "UART Baud rate. It must be a pre-defined
+value in src/nrf52840/transport-config.h")
+add_definitions(-DUART_BAUDRATE=NRF_UARTE_BAUDRATE_${OT_UART_BAUDRATE})
+
 add_library(openthread-nrf52840
     ${NRF_COMM_SOURCES}
     ${NRF_SINGLEPHY_SOURCES}


### PR DESCRIPTION
Sample usage:

```
./script/build nrf52840 UART_trans  -DOT_UART_BAUDRATE=460800
```