### PR TITLE
[git] add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,48 @@
+*.a
+*.bak
+*.db
+*.flash
+*.gcda
+*.gcno
+*.log
+*.o
+*.lo
+*.la
+*.ninja*
+*.opendb
+*.orig
+*.pcap
+*.pyc
+*.suo
+*.swn
+*.swo
+*.swp
+*.trs
+*.user
+*.bak
+*~
+.deps
+.dirstamp
+.DS_Store
+.local-version
+.libs
+.vagrant
+
+# CMake
+build
+CMakeCache.txt
+CMakeFiles
+cmake_install.cmake
+
+# IDE / editor files
+.idea/**
+.vscode/**
+cmake-build-*/**
+/tags
+
+# Python bytecodes
+__pycache__
+
+# Images
+*.hex
+*.zip


### PR DESCRIPTION
This commit adds the `openthread/.gitignore` in this repository to ignore any intermediate
files generated by this project or openthread.

Also ignores `*.hex` and `*.zip` files which are usually nRF528XX firmwares.