### PR TITLE
[config] include the default user configuration header

### DIFF
--- a/third_party/NordicSemiconductor/drivers/radio/nrf_802154_config.h
+++ b/third_party/NordicSemiconductor/drivers/radio/nrf_802154_config.h
@@ -33,6 +33,10 @@
 
 #ifdef NRF_802154_PROJECT_CONFIG
 #include NRF_802154_PROJECT_CONFIG
+#elif defined(NRF_802154_USER_CONFIG)
+// This configuration header file should be provided by the user when
+// NRF_802154_USER_CONFIG is defined to 1.
+#include "nrf_802154_user_config.h"
 #endif
 
 #include <nrf.h>

--- a/third_party/NordicSemiconductor/drivers/radio/rsch/raal/nrf_raal_config.h
+++ b/third_party/NordicSemiconductor/drivers/radio/rsch/raal/nrf_raal_config.h
@@ -33,6 +33,10 @@
 
 #ifdef NRF_802154_PROJECT_CONFIG
 #include NRF_802154_PROJECT_CONFIG
+#elif defined(NRF_802154_USER_CONFIG)
+// This configuration header file should be provided by the user when
+// NRF_802154_USER_CONFIG is defined to 1.
+#include "nrf_802154_user_config.h"
 #endif
 
 #include <nrf.h>


### PR DESCRIPTION
ot-nrf528xx uses the compile option
`-DNRF_802154_PROJECT_CONFIG=\"platform-config.h\"` to specify the
Nordic library configuration file. Some build systems do not support this
usage.

This commit includes the default user implemented configuration header
file to avoid specifying the configuration file.