### PR TITLE
[csl] avoid overwritting IEs for retransmissions

### DIFF
--- a/src/src/radio.c
+++ b/src/src/radio.c
@@ -1221,7 +1221,7 @@ void nrf_802154_tx_started(const uint8_t *aFrame)
     OT_UNUSED_VARIABLE(aFrame);
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    if (sCslPeriod > 0)
+    if ((sCslPeriod > 0) && !sTransmitFrame.mInfo.mTxInfo.mIsARetx)
     {
         otMacFrameSetCslIe(&sTransmitFrame, (uint16_t)sCslPeriod, getCslPhase());
     }


### PR DESCRIPTION
For a CSL retransmission, avoid to inject the CSL IE since it would break the frame encryption.