### PR TITLE
[usb] implement `otPlatUartFlush` for USB

### DIFF
--- a/src/src/transport/usb-cdc-uart.c
+++ b/src/src/transport/usb-cdc-uart.c
@@ -366,7 +366,14 @@ exit:
 
 otError otPlatUartFlush(void)
 {
-    return OT_ERROR_NOT_IMPLEMENTED;
+    while (sUsbState.mTransferInProgress && !sUsbState.mTransferDone)
+    {
+        // Wait until the transmission is done
+    }
+
+    processTransmit();
+
+    return OT_ERROR_NONE;
 }
 
 #endif // USB_CDC_AS_SERIAL_TRANSPORT == 1


### PR DESCRIPTION
Address issue #178:
OpenThread CLI output may be lost in USB CDC mode because
otPlatUartFlush is not implemented

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>