### PR TITLE
[spi] fix issue with SPI transaction being too short

### DIFF
--- a/src/src/transport/spi-slave.c
+++ b/src/src/transport/spi-slave.c
@@ -79,7 +79,7 @@ static void spisEventHandler(nrfx_spis_evt_t const *aEvent, void *aContext)
 
         // Execute application callback.
         if (sCompleteCallback(sContext, aEvent->tx_buffer, aEvent->tx_buffer_size, aEvent->rx_buffer,
-                              aEvent->rx_buffer_size, aEvent->rx_amount))
+                              aEvent->rx_buffer_size, MAX(aEvent->rx_amount, aEvent->tx_amount)))
         {
             // Further processing is required.
             sFurtherProcessingFlag = true;


### PR DESCRIPTION
Issue #7224 was reported that aTransactionLength parameter of SPI
otPlatSpiSlaveTransactionCompleteCallback callback is used incorrectly
by passing only received buffer size instead of real transaction
length.
The driver does not provide functionality to get this value, however in
this case providing maximum of the received and transmitted lengths
should do the trick.

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>

Fixes https://github.com/openthread/openthread/issues/7224