### PR TITLE
Add docker build instructions

### DIFF
--- a/src/nrf52840/README.md
+++ b/src/nrf52840/README.md
@@ -60,6 +60,28 @@ After a successful build, the `elf` files can be found in `<path-to-ot-nrf528xx>
 $ arm-none-eabi-objcopy -O ihex build/bin/ot-cli-ftd ot-cli-ftd.hex
 ```
 
+### Alternative build using Docker
+
+Alternatively, it's possible to build using a Docker image.
+
+This can be useful in case of CI/CD builds or to build locally without installing the dependencies.
+
+Example for the nRF52840 dongle:
+
+```bash
+cd <path-to-ot-nrf528xx>
+docker run --rm -u $(id -u):$(id -g) -v $(pwd):/workdir/project coderbyheart/fw-nrfconnect-nrf-docker:v1.8-branch ./script/build nrf52840 USB_trans -DOT_BOOTLOADER=USB -DOT_THREAD_VERSION=1.2
+```
+
+Then `elf` files can be converted through the same container image.
+
+For example:
+
+```bash
+cd <path-to-ot-nrf528xx>
+docker run --rm -u $(id -u):$(id -g) -v $(pwd):/workdir/project coderbyheart/fw-nrfconnect-nrf-docker:v1.8-branch arm-none-eabi-objcopy -O ihex build/bin/ot-rcp build/bin/ot-rcp.hex
+```
+
 ### USB CDC ACM support
 
 You can build the libraries with support for the native USB CDC ACM as a serial transport. To do so, build the firmware with the following parameter:


### PR DESCRIPTION
Show how openthread can also be built through docker.

This is using the image from coderbyheart which I think is as official as we can get right now for an nRF Connect SDK docker image.

Following is the build output of current latest `8c6658f6263a8ec1e8135534133a96770b9bb065` using image `sha256:2af43c0b698b5bae084eea409a46ac63006485dde46e34cd7cc25e8b29fca082`:

```
fgervais@fgervais-System-Product-Name:~/personal/ot-nrf528xx-fg$ docker run --rm -u $(id -u):$(id -g) -v $(pwd):/workdir/project coderbyheart/fw-nrfconnect-nrf-docker:v1.8-branch ./script/build nrf52840 USB_trans -DOT_BOOTLOADER=USB -DOT_THREAD_VERSION=1.2
+ OT_CMAKE_NINJA_TARGET=
+ NRF_PLATFORMS=(nrf52811 nrf52833 nrf52840)
+ readonly NRF_PLATFORMS
+ NRF_BUILD_TYPES=(UART_trans USB_trans SPI_trans_NCP soft_crypto soft_crypto_threading)
+ readonly NRF_BUILD_TYPES
++ pwd
+ readonly OT_SRCDIR=/workdir/project
+ OT_SRCDIR=/workdir/project
+ OT_OPTIONS=("-DCMAKE_BUILD_TYPE=MinSizeRel" "-DOT_PLATFORM=external" "-DOT_SLAAC=ON")
+ readonly OT_OPTIONS
+ main nrf52840 USB_trans -DOT_BOOTLOADER=USB -DOT_THREAD_VERSION=1.2
+ [[ 4 == 0 ]]
+ local platform=nrf52840
+ echo nrf52811 nrf52833 nrf52840
+ grep -wq nrf52840
+ [[ 4 == 1 ]]
+ local nrf_build_type=USB_trans
+ echo UART_trans USB_trans SPI_trans_NCP soft_crypto soft_crypto_threading
+ grep -wq USB_trans
+ shift
+ shift
+ local_options=()
+ local local_options
+ options=("${OT_OPTIONS[@]}")
+ local options
+ case "${platform}" in
+ local_options+=("-DCMAKE_TOOLCHAIN_FILE=src/${platform}/arm-none-eabi.cmake")
+ case "${nrf_build_type}" in
+ options+=("${local_options[@]}" "-DOT_USB=ON" "-DOT_EXTERNAL_MBEDTLS=nordicsemi-mbedtls")
+ options+=("$@")
+ build -DNRF_PLATFORM=nrf52840 -DCMAKE_BUILD_TYPE=MinSizeRel -DOT_PLATFORM=external -DOT_SLAAC=ON -DCMAKE_TOOLCHAIN_FILE=src/nrf52840/arm-none-eabi.cmake -DOT_USB=ON -DOT_EXTERNAL_MBEDTLS=nordicsemi-mbedtls -DOT_BOOTLOADER=USB -DOT_THREAD_VERSION=1.2
+ local builddir=build
+ mkdir -p build
+ cd build
+ cmake -GNinja -DOT_COMPILE_WARNING_AS_ERROR=ON -DNRF_PLATFORM=nrf52840 -DCMAKE_BUILD_TYPE=MinSizeRel -DOT_PLATFORM=external -DOT_SLAAC=ON -DCMAKE_TOOLCHAIN_FILE=src/nrf52840/arm-none-eabi.cmake -DOT_USB=ON -DOT_EXTERNAL_MBEDTLS=nordicsemi-mbedtls -DOT_BOOTLOADER=USB -DOT_THREAD_VERSION=1.2 /workdir/project
-- The C compiler identification is GNU 9.2.1
-- The CXX compiler identification is GNU 9.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /workdir/gcc-arm-none-eabi-9-2019-q4-major/bin/arm-none-eabi-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /workdir/gcc-arm-none-eabi-9-2019-q4-major/bin/arm-none-eabi-g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- OpenThread Source Directory: /workdir/project/openthread
-- OpenThread CMake build type: MinSizeRel
-- Package Name: OPENTHREAD
-- Setting default package version: thread-reference-20200818-1511-g74f5ab5c9
-- Package Version: thread-reference-20200818-1511-g74f5ab5c9
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_TOOLCHAIN_FILE


-- Build files have been written to: /workdir/project/build
+ [[ -n '' ]]
+ ninja
[1/712] Building C object openthread/examples/platforms/utils/CMakeFiles/openthread-platform-utils.dir/settings_ram.c.obj
[2/712] Building C object openthread/examples/platforms/utils/CMakeFiles/openthread-platform-utils.dir/logging_rtt.c.obj
[3/712] Building CXX object openthread/examples/platforms/utils/CMakeFiles/openthread-platform-utils.dir/otns_utils.cpp.obj
[4/712] Building C object openthread/examples/apps/cli/CMakeFiles/ot-cli-mtd.dir/main.c.obj
[5/712] Building C object openthread/examples/apps/ncp/CMakeFiles/ot-ncp-ftd.dir/ncp.c.obj
[6/712] Building C object openthread/examples/platforms/utils/CMakeFiles/openthread-platform-utils.dir/debug_uart.c.obj
[7/712] Building C object openthread/examples/platforms/utils/CMakeFiles/openthread-platform-utils.dir/soft_source_match_table.c.obj
[8/712] Building C object openthread/examples/apps/cli/CMakeFiles/ot-cli-ftd.dir/main.c.obj
[9/712] Building C object openthread/examples/apps/cli/CMakeFiles/ot-cli-radio.dir/main.c.obj
[10/712] Building C object openthread/examples/apps/ncp/CMakeFiles/ot-ncp-ftd.dir/main.c.obj
[11/712] Building CXX object openthread/examples/apps/cli/CMakeFiles/ot-cli-ftd.dir/cli_uart.cpp.obj
[12/712] Building C object openthread/examples/apps/ncp/CMakeFiles/ot-ncp-mtd.dir/main.c.obj
[13/712] Building CXX object openthread/examples/platforms/utils/CMakeFiles/openthread-platform-utils.dir/link_metrics.cpp.obj
[14/712] Building CXX object openthread/examples/apps/cli/CMakeFiles/ot-cli-mtd.dir/cli_uart.cpp.obj
[15/712] Building C object openthread/examples/apps/ncp/CMakeFiles/ot-ncp-mtd.dir/ncp.c.obj
[16/712] Building CXX object openthread/examples/apps/cli/CMakeFiles/ot-cli-radio.dir/cli_uart.cpp.obj
[17/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-ftd.dir/cli_coap.cpp.obj
[18/712] Building C object openthread/examples/apps/ncp/CMakeFiles/ot-rcp.dir/main.c.obj
[19/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-ftd.dir/cli_coap_secure.cpp.obj
[20/712] Building C object openthread/examples/apps/ncp/CMakeFiles/ot-rcp.dir/ncp.c.obj
[21/712] Building CXX object openthread/examples/platforms/utils/CMakeFiles/openthread-platform-utils.dir/mac_frame.cpp.obj
[22/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-ftd.dir/cli_history.cpp.obj
[23/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-mtd.dir/cli_coap.cpp.obj
[24/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-mtd.dir/cli_coap_secure.cpp.obj
[25/712] cd /workdir/project/build/openthread && /usr/local/lib/python3.8/dist-packages/cmake/data/bin/cmake -DLIST="OPENTHREAD_CONFIG_ASSERT_ENABLE=1;OPENTHREAD_CONFIG_BACKBONE_ROUTER_DUA_NDPROXYING_ENABLE=0;OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE=0;OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS=0;OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS_MANAGEMENT=1;OPENTHREAD_CONFIG_MAC_CSL_AUTO_SYNC_ENABLE=0;OPENTHREAD_CONFIG_PING_SENDER_ENABLE=1;OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE=1;OPENTHREAD_SPINEL_CONFIG_RCP_RESTORATION_MAX_COUNT=0;PACKAGE_NAME="OPENTHREAD";OPENTHREAD_CONFIG_THREAD_VERSION=OT_THREAD_VERSION_1_2;OPENTHREAD_CONFIG_NCP_HDLC_ENABLE=1;OPENTHREAD_CONFIG_FILE="openthread-core-nrf52840-config.h";OPENTHREAD_PROJECT_CORE_CONFIG_FILE="openthread-core-nrf52840-config.h";OPENTHREAD_CORE_CONFIG_PLATFORM_CHECK_FILE="openthread-core-nrf52840-config-check.h";MBEDTLS_USER_CONFIG_FILE="nrf52840-mbedtls-config.h";USB_CDC_AS_SERIAL_TRANSPORT=1;APP_USBD_NRF_DFU_TRIGGER_ENABLED=1;OPENTHREAD_CORE_CONFIG_PLATFORM_CHECK_FILE="openthread-core-nrf52840-config-check.h";MBEDTLS_CONFIG_FILE="nrf-config.h"" -P /workdir/project/openthread/etc/cmake/print.cmake
OPENTHREAD_CONFIG_ASSERT_ENABLE=1
OPENTHREAD_CONFIG_BACKBONE_ROUTER_DUA_NDPROXYING_ENABLE=0
OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE=0
OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS=0
OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS_MANAGEMENT=1
OPENTHREAD_CONFIG_MAC_CSL_AUTO_SYNC_ENABLE=0
OPENTHREAD_CONFIG_PING_SENDER_ENABLE=1
OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE=1
OPENTHREAD_SPINEL_CONFIG_RCP_RESTORATION_MAX_COUNT=0
PACKAGE_NAME=OPENTHREAD
OPENTHREAD_CONFIG_THREAD_VERSION=OT_THREAD_VERSION_1_2
OPENTHREAD_CONFIG_NCP_HDLC_ENABLE=1
OPENTHREAD_CONFIG_FILE=openthread-core-nrf52840-config.h
OPENTHREAD_PROJECT_CORE_CONFIG_FILE=openthread-core-nrf52840-config.h
OPENTHREAD_CORE_CONFIG_PLATFORM_CHECK_FILE=openthread-core-nrf52840-config-check.h
MBEDTLS_USER_CONFIG_FILE=nrf52840-mbedtls-config.h
USB_CDC_AS_SERIAL_TRANSPORT=1
APP_USBD_NRF_DFU_TRIGGER_ENABLED=1
OPENTHREAD_CORE_CONFIG_PLATFORM_CHECK_FILE=openthread-core-nrf52840-config-check.h
MBEDTLS_CONFIG_FILE=nrf-config.h
[26/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-ftd.dir/cli_output.cpp.obj
[27/712] Linking CXX static library lib/libopenthread-platform-utils-static.a
[28/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-ftd.dir/cli_srp_client.cpp.obj
[29/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-mtd.dir/cli_history.cpp.obj
[30/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-mtd.dir/cli_srp_client.cpp.obj
[31/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-mtd.dir/cli_output.cpp.obj
[32/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-mtd.dir/cli_commissioner.cpp.obj
[33/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-ftd.dir/cli_commissioner.cpp.obj
[34/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-ftd.dir/cli_network_data.cpp.obj
[35/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-radio.dir/cli_output.cpp.obj
[36/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-ftd.dir/cli_joiner.cpp.obj
[37/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-ftd.dir/cli_tcp.cpp.obj
[38/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-ftd.dir/cli_udp.cpp.obj
[39/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-mtd.dir/cli_joiner.cpp.obj
[40/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-ftd.dir/cli_dataset.cpp.obj
[41/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-mtd.dir/cli_srp_server.cpp.obj
[42/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/backbone_router_ftd_api.cpp.obj
[43/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/border_agent_api.cpp.obj
[44/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-mtd.dir/cli_network_data.cpp.obj
[45/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-mtd.dir/cli_tcp.cpp.obj
[46/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-radio.dir/cli.cpp.obj
[47/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/border_router_api.cpp.obj
[48/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/channel_monitor_api.cpp.obj
[49/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-mtd.dir/cli_dataset.cpp.obj
[50/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/channel_manager_api.cpp.obj
[51/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/child_supervision_api.cpp.obj
[52/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/coap_api.cpp.obj
[53/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-ftd.dir/cli_srp_server.cpp.obj
[54/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/coap_secure_api.cpp.obj
[55/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/commissioner_api.cpp.obj
[56/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/diags_api.cpp.obj
[57/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-mtd.dir/cli.cpp.obj
[58/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/dataset_updater_api.cpp.obj
[59/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-mtd.dir/cli_udp.cpp.obj
[60/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/error_api.cpp.obj
[61/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/heap_api.cpp.obj
[62/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/jam_detection_api.cpp.obj
[63/712] Building CXX object openthread/src/cli/CMakeFiles/openthread-cli-ftd.dir/cli.cpp.obj
[64/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/history_tracker_api.cpp.obj
[65/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/joiner_api.cpp.obj
[66/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/link_raw_api.cpp.obj
[67/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/link_metrics_api.cpp.obj
[68/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/multi_radio_api.cpp.obj
[69/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/netdata_publisher_api.cpp.obj
[70/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/backbone_router_api.cpp.obj
[71/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/network_time_api.cpp.obj
[72/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/radio/radio.cpp.obj
[73/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/sntp_api.cpp.obj
[74/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/server_api.cpp.obj
[75/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/dns_server_api.cpp.obj
[76/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/crypto_api.cpp.obj
[77/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/random_crypto_api.cpp.obj
[78/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/dataset_ftd_api.cpp.obj
[79/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/random_noncrypto_api.cpp.obj
[80/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/dataset_api.cpp.obj
[81/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/dns_api.cpp.obj
[82/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/srp_client_api.cpp.obj
[83/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/srp_server_api.cpp.obj
[84/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/icmp6_api.cpp.obj
[85/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/ip6_api.cpp.obj
[86/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/trel_api.cpp.obj
[87/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/backbone_router/backbone_tmf.cpp.obj
[88/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/instance_api.cpp.obj
[89/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/backbone_router/bbr_manager.cpp.obj
[90/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/logging_api.cpp.obj
[91/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/backbone_router/multicast_listeners_table.cpp.obj
[92/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/backbone_router/bbr_local.cpp.obj
[93/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/ping_sender_api.cpp.obj
[94/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/backbone_router/ndproxy_table.cpp.obj
[95/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/link_api.cpp.obj
[96/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/border_router/infra_if_platform.cpp.obj
[97/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/message_api.cpp.obj
[98/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/border_router/router_advertisement.cpp.obj
[99/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/border_router/routing_manager.cpp.obj
[100/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/netdata_api.cpp.obj
[101/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/netdiag_api.cpp.obj
[102/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/coap/coap_secure.cpp.obj
[103/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/common/binary_search.cpp.obj
[104/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/common/error.cpp.obj
[105/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/common/crc16.cpp.obj
[106/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/common/data.cpp.obj
[107/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/common/heap_string.cpp.obj
[108/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/common/appender.cpp.obj
[109/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/srp_client_buffers_api.cpp.obj
[110/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/tasklet_api.cpp.obj
[111/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/common/heap_data.cpp.obj
[112/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/common/random_manager.cpp.obj
[113/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/tcp_api.cpp.obj
[114/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/net/dnssd_server.cpp.obj
[115/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/common/string.cpp.obj
[116/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/thread_api.cpp.obj
[117/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/thread_ftd_api.cpp.obj
[118/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/backbone_router/bbr_leader.cpp.obj
[119/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/api/udp_api.cpp.obj
[120/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/common/uptime.cpp.obj
[121/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/common/trickle_timer.cpp.obj
[122/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/common/heap.cpp.obj
[123/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/coap/coap.cpp.obj
[124/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/coap/coap_message.cpp.obj
[125/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/crypto/aes_ecb.cpp.obj
[126/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/crypto/ecdsa.cpp.obj
[127/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/common/logging.cpp.obj
[128/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/common/tlvs.cpp.obj
[129/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/crypto/aes_ccm.cpp.obj
[130/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/crypto/hkdf_sha256.cpp.obj
[131/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/diags/factory_diags.cpp.obj
[132/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/crypto/pbkdf2_cmac.cpp.obj
[133/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/common/notifier.cpp.obj
[134/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/crypto/storage.cpp.obj
[135/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/crypto/hmac_sha256.cpp.obj
[136/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/mac/link_raw.cpp.obj
[137/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/crypto/mbedtls.cpp.obj
[138/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/common/instance.cpp.obj
[139/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/crypto/sha256.cpp.obj
[140/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/mac/mac_filter.cpp.obj
[141/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/mac/channel_mask.cpp.obj
[142/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/common/message.cpp.obj
[143/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/common/settings.cpp.obj
[144/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/meshcop/announce_begin_client.cpp.obj
[145/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/common/time_ticker.cpp.obj
[146/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/meshcop/border_agent.cpp.obj
[147/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/meshcop/commissioner.cpp.obj
[148/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/common/tasklet.cpp.obj
[149/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/mac/mac_types.cpp.obj
[150/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/meshcop/dataset_updater.cpp.obj
[151/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/common/timer.cpp.obj
[152/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/mac/mac_frame.cpp.obj
[153/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/meshcop/energy_scan_client.cpp.obj
[154/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/meshcop/joiner.cpp.obj
[155/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/crypto/crypto_platform.cpp.obj
[156/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/meshcop/panid_query_client.cpp.obj
[157/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/mac/data_poll_sender.cpp.obj
[158/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/mac/data_poll_handler.cpp.obj
[159/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/net/dhcp6_client.cpp.obj
[160/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/mac/mac_links.cpp.obj
[161/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/meshcop/timestamp.cpp.obj
[162/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/mac/sub_mac_callbacks.cpp.obj
[163/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/net/dhcp6_server.cpp.obj
[164/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/net/dns_client.cpp.obj
[165/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/net/checksum.cpp.obj
[166/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/net/dns_dso.cpp.obj
[167/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/mac/sub_mac.cpp.obj
[168/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/net/dnssd_server.cpp.obj
[169/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/meshcop/dataset_local.cpp.obj
[170/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/net/ip4_address.cpp.obj
[171/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/meshcop/meshcop_tlvs.cpp.obj
[172/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/meshcop/dtls.cpp.obj
[173/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/net/nd_agent.cpp.obj
[174/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/meshcop/dataset.cpp.obj
[175/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/mac/mac.cpp.obj
[176/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/meshcop/dataset_manager_ftd.cpp.obj
[177/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/meshcop/dataset_manager.cpp.obj
[178/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/net/sntp_client.cpp.obj
[179/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/net/srp_client.cpp.obj
[180/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/meshcop/joiner_router.cpp.obj
[181/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/meshcop/meshcop.cpp.obj
[182/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/net/srp_server.cpp.obj
[183/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/meshcop/meshcop_leader.cpp.obj
[184/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/net/ip6_headers.cpp.obj
[185/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/net/socket.cpp.obj
[186/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/radio/trel_interface.cpp.obj
[187/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/radio/trel_packet.cpp.obj
[188/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/radio/trel_link.cpp.obj
[189/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/anycast_locator.cpp.obj
[190/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/net/icmp6.cpp.obj
[191/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/net/ip6_mpl.cpp.obj
[192/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/net/ip6_filter.cpp.obj
[193/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/net/dns_types.cpp.obj
[194/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/net/ip6_address.cpp.obj
[195/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/radio/radio_callbacks.cpp.obj
[196/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/net/ip6.cpp.obj
[197/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/net/netif.cpp.obj
[198/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/link_metrics.cpp.obj
[199/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/radio/radio_platform.cpp.obj
[200/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/announce_sender.cpp.obj
[201/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/net/udp6.cpp.obj
[202/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/announce_begin_server.cpp.obj
[203/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/net/tcp6.cpp.obj
[204/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/csl_tx_scheduler.cpp.obj
[205/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/child_table.cpp.obj
[206/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/discover_scanner.cpp.obj
[207/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/dua_manager.cpp.obj
[208/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/address_resolver.cpp.obj
[209/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/mle_types.cpp.obj
[210/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/energy_scan_server.cpp.obj
[211/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/network_data_local.cpp.obj
[212/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/indirect_sender.cpp.obj
[213/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/link_quality.cpp.obj
[214/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/mesh_forwarder_mtd.cpp.obj
[215/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/key_manager.cpp.obj
[216/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/network_data_publisher.cpp.obj
[217/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/network_data_tlvs.cpp.obj
[218/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/lowpan.cpp.obj
[219/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/radio_selector.cpp.obj
[220/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/mesh_forwarder_ftd.cpp.obj
[221/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/mesh_forwarder.cpp.obj
[222/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/neighbor_table.cpp.obj
[223/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/time_sync_service.cpp.obj
[224/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/network_data_leader.cpp.obj
[225/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/uri_paths.cpp.obj
[226/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/network_data_notifier.cpp.obj
[227/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/mlr_manager.cpp.obj
[228/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/utils/channel_monitor.cpp.obj
[229/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/network_data.cpp.obj
[230/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/utils/channel_manager.cpp.obj
[231/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/network_data_service.cpp.obj
[232/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/utils/history_tracker.cpp.obj
[233/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/network_data_types.cpp.obj
[234/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/utils/jam_detector.cpp.obj
[235/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/utils/heap.cpp.obj
[236/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/network_data_leader_ftd.cpp.obj
[237/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/utils/otns.cpp.obj
[238/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/utils/srp_client_buffers.cpp.obj
[239/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/panid_query_server.cpp.obj
[240/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/utils/parse_cmdline.cpp.obj
[241/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/border_agent_api.cpp.obj
[242/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/router_table.cpp.obj
[243/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/child_supervision_api.cpp.obj
[244/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/coap_api.cpp.obj
[245/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/src_match_controller.cpp.obj
[246/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/coap_secure_api.cpp.obj
[247/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/thread_netif.cpp.obj
[248/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/border_router_api.cpp.obj
[249/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/channel_manager_api.cpp.obj
[250/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/channel_monitor_api.cpp.obj
[251/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/backbone_router_ftd_api.cpp.obj
[252/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/tmf.cpp.obj
[253/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/commissioner_api.cpp.obj
[254/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/dataset_updater_api.cpp.obj
[255/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/dataset_ftd_api.cpp.obj
[256/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/network_diagnostic.cpp.obj
[257/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/utils/child_supervision.cpp.obj
[258/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/error_api.cpp.obj
[259/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/diags_api.cpp.obj
[260/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/heap_api.cpp.obj
[261/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/history_tracker_api.cpp.obj
[262/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/mle.cpp.obj
[263/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/topology.cpp.obj
[264/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/utils/flash.cpp.obj
[265/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/thread/mle_router.cpp.obj
[266/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/joiner_api.cpp.obj
[267/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/jam_detection_api.cpp.obj
[268/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/link_metrics_api.cpp.obj
[269/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/link_raw_api.cpp.obj
[270/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/utils/slaac_address.cpp.obj
[271/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/multi_radio_api.cpp.obj
[272/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/netdiag_api.cpp.obj
[273/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/netdata_publisher_api.cpp.obj
[274/712] Building CXX object openthread/src/core/CMakeFiles/openthread-ftd.dir/utils/ping_sender.cpp.obj
[275/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/network_time_api.cpp.obj
[276/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/backbone_router_api.cpp.obj
[277/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/crypto_api.cpp.obj
[278/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/random_crypto_api.cpp.obj
[279/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/server_api.cpp.obj
[280/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/dns_server_api.cpp.obj
[281/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/sntp_api.cpp.obj
[282/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/dataset_api.cpp.obj
[283/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/random_noncrypto_api.cpp.obj
[284/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/srp_client_api.cpp.obj
[285/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/srp_server_api.cpp.obj
[286/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/dns_api.cpp.obj
[287/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/trel_api.cpp.obj
[288/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/thread_ftd_api.cpp.obj
[289/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/icmp6_api.cpp.obj
[290/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/instance_api.cpp.obj
[291/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/backbone_router/backbone_tmf.cpp.obj
[292/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/backbone_router/bbr_manager.cpp.obj
[293/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/ip6_api.cpp.obj
[294/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/logging_api.cpp.obj
[295/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/backbone_router/multicast_listeners_table.cpp.obj
[296/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/backbone_router/bbr_local.cpp.obj
[297/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/border_router/router_advertisement.cpp.obj
[298/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/backbone_router/ndproxy_table.cpp.obj
[299/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/border_router/infra_if_platform.cpp.obj
[300/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/border_router/routing_manager.cpp.obj
[301/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/netdata_api.cpp.obj
[302/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/link_api.cpp.obj
[303/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/message_api.cpp.obj
[304/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/coap/coap_secure.cpp.obj
[305/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/common/binary_search.cpp.obj
[306/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/common/crc16.cpp.obj
[307/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/ping_sender_api.cpp.obj
[308/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/common/data.cpp.obj
[309/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/common/error.cpp.obj
[310/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/common/appender.cpp.obj
[311/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/common/heap_string.cpp.obj
[312/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/srp_client_buffers_api.cpp.obj
[313/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/common/heap_data.cpp.obj
[314/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/tasklet_api.cpp.obj
[315/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/tcp_api.cpp.obj
[316/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/common/random_manager.cpp.obj
[317/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/common/string.cpp.obj
[318/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/backbone_router/bbr_leader.cpp.obj
[319/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/udp_api.cpp.obj
[320/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/common/uptime.cpp.obj
[321/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/api/thread_api.cpp.obj
[322/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/common/trickle_timer.cpp.obj
[323/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/crypto/aes_ecb.cpp.obj
[324/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/common/heap.cpp.obj
[325/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/crypto/hkdf_sha256.cpp.obj
[326/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/common/tlvs.cpp.obj
[327/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/crypto/aes_ccm.cpp.obj
[328/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/crypto/ecdsa.cpp.obj
[329/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/coap/coap_message.cpp.obj
[330/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/common/logging.cpp.obj
[331/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/common/instance.cpp.obj
[332/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/crypto/pbkdf2_cmac.cpp.obj
[333/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/crypto/storage.cpp.obj
[334/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/common/notifier.cpp.obj
[335/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/diags/factory_diags.cpp.obj
[336/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/coap/coap.cpp.obj
[337/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/common/tasklet.cpp.obj
[338/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/crypto/hmac_sha256.cpp.obj
[339/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/mac/data_poll_handler.cpp.obj
[340/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/common/settings.cpp.obj
[341/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/crypto/mbedtls.cpp.obj
[342/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/mac/link_raw.cpp.obj
[343/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/mac/mac_filter.cpp.obj
[344/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/crypto/sha256.cpp.obj
[345/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/mac/channel_mask.cpp.obj
[346/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/meshcop/border_agent.cpp.obj
[347/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/meshcop/announce_begin_client.cpp.obj
[348/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/meshcop/commissioner.cpp.obj
[349/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/common/time_ticker.cpp.obj
[350/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/common/message.cpp.obj
[351/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/common/timer.cpp.obj
[352/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/mac/mac_types.cpp.obj
[353/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/meshcop/dataset_updater.cpp.obj
[354/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/meshcop/energy_scan_client.cpp.obj
[355/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/meshcop/joiner.cpp.obj
[356/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/meshcop/joiner_router.cpp.obj
[357/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/mac/mac_frame.cpp.obj
[358/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/meshcop/panid_query_client.cpp.obj
[359/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/crypto/crypto_platform.cpp.obj
[360/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/meshcop/meshcop_leader.cpp.obj
[361/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/meshcop/timestamp.cpp.obj
[362/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/mac/sub_mac_callbacks.cpp.obj
[363/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/net/dhcp6_client.cpp.obj
[364/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/net/dhcp6_server.cpp.obj
[365/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/meshcop/dataset_manager_ftd.cpp.obj
[366/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/net/dns_client.cpp.obj
[367/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/net/dns_dso.cpp.obj
[368/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/mac/mac_links.cpp.obj
[369/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/mac/data_poll_sender.cpp.obj
[370/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/net/checksum.cpp.obj
[371/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/net/ip4_address.cpp.obj
[372/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/mac/sub_mac.cpp.obj
[373/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/mac/mac.cpp.obj
[374/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/meshcop/dataset_local.cpp.obj
[375/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/net/nd_agent.cpp.obj
[376/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/meshcop/dtls.cpp.obj
[377/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/net/sntp_client.cpp.obj
[378/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/meshcop/meshcop_tlvs.cpp.obj
[379/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/meshcop/meshcop.cpp.obj
[380/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/net/srp_client.cpp.obj
[381/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/net/srp_server.cpp.obj
[382/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/meshcop/dataset_manager.cpp.obj
[383/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/net/ip6_headers.cpp.obj
[384/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/net/socket.cpp.obj
[385/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/meshcop/dataset.cpp.obj
[386/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/radio/trel_interface.cpp.obj
[387/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/radio/trel_packet.cpp.obj
[388/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/radio/trel_link.cpp.obj
[389/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/address_resolver.cpp.obj
[390/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/anycast_locator.cpp.obj
[391/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/net/icmp6.cpp.obj
[392/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/net/ip6.cpp.obj
[393/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/child_table.cpp.obj
[394/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/csl_tx_scheduler.cpp.obj
[395/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/net/dns_types.cpp.obj
[396/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/net/ip6_filter.cpp.obj
[397/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/dua_manager.cpp.obj
[398/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/net/ip6_mpl.cpp.obj
[399/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/net/ip6_address.cpp.obj
[400/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/indirect_sender.cpp.obj
[401/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/net/netif.cpp.obj
[402/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/link_metrics.cpp.obj
[403/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/radio/radio_callbacks.cpp.obj
[404/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/radio/radio.cpp.obj
[405/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/radio/radio_platform.cpp.obj
[406/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/mlr_manager.cpp.obj
[407/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/net/udp6.cpp.obj
[408/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/announce_begin_server.cpp.obj
[409/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/mle_types.cpp.obj
[410/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/net/tcp6.cpp.obj
[411/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/announce_sender.cpp.obj
[412/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/network_data_local.cpp.obj
[413/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/network_data_notifier.cpp.obj
[414/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/mesh_forwarder_ftd.cpp.obj
[415/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/network_data_publisher.cpp.obj
[416/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/link_quality.cpp.obj
[417/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/energy_scan_server.cpp.obj
[418/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/key_manager.cpp.obj
[419/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/mesh_forwarder_mtd.cpp.obj
[420/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/discover_scanner.cpp.obj
[421/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/mle_router.cpp.obj
[422/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/network_diagnostic.cpp.obj
[423/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/src_match_controller.cpp.obj
[424/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/radio_selector.cpp.obj
[425/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/router_table.cpp.obj
[426/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/time_sync_service.cpp.obj
[427/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/network_data_tlvs.cpp.obj
[428/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/utils/channel_monitor.cpp.obj
[429/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/lowpan.cpp.obj
[430/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/neighbor_table.cpp.obj
[431/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/uri_paths.cpp.obj
[432/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/utils/channel_manager.cpp.obj
[433/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/mesh_forwarder.cpp.obj
[434/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/network_data_leader_ftd.cpp.obj
[435/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/utils/history_tracker.cpp.obj
[436/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/utils/heap.cpp.obj
[437/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/utils/jam_detector.cpp.obj
[438/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/utils/otns.cpp.obj
[439/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/network_data.cpp.obj
[440/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/network_data_service.cpp.obj
[441/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/utils/srp_client_buffers.cpp.obj
[442/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/network_data_types.cpp.obj
[443/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/utils/parse_cmdline.cpp.obj
[444/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/network_data_leader.cpp.obj
[445/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/topology.cpp.obj
[446/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/api/random_noncrypto_api.cpp.obj
[447/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/panid_query_server.cpp.obj
[448/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/thread_netif.cpp.obj
[449/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/common/binary_search.cpp.obj
[450/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/tmf.cpp.obj
[451/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/common/error.cpp.obj
[452/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/api/diags_api.cpp.obj
[453/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/api/instance_api.cpp.obj
[454/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/utils/child_supervision.cpp.obj
[455/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/api/tasklet_api.cpp.obj
[456/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/api/error_api.cpp.obj
[457/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/common/uptime.cpp.obj
[458/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/common/random_manager.cpp.obj
[459/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/common/string.cpp.obj
[460/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/common/instance.cpp.obj
[461/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/api/logging_api.cpp.obj
[462/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/api/link_raw_api.cpp.obj
[463/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/utils/flash.cpp.obj
[464/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/crypto/storage.cpp.obj
[465/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/crypto/aes_ecb.cpp.obj
[466/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/diags/factory_diags.cpp.obj
[467/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/common/logging.cpp.obj
[468/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/common/tasklet.cpp.obj
[469/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/crypto/aes_ccm.cpp.obj
[470/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/utils/ping_sender.cpp.obj
[471/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/utils/slaac_address.cpp.obj
[472/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/common/timer.cpp.obj
[473/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/crypto/crypto_platform.cpp.obj
[474/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/mac/link_raw.cpp.obj
[475/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/mac/mac_types.cpp.obj
[476/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/api/diags_api.cpp.obj
[477/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/mac/sub_mac_callbacks.cpp.obj
[478/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/api/error_api.cpp.obj
[479/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/radio/radio_callbacks.cpp.obj
[480/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/common/binary_search.cpp.obj
[481/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/radio/radio.cpp.obj
[482/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/api/random_noncrypto_api.cpp.obj
[483/712] Building CXX object openthread/src/core/CMakeFiles/openthread-mtd.dir/thread/mle.cpp.obj
[484/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/common/error.cpp.obj
[485/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/radio/radio_platform.cpp.obj
[486/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/utils/parse_cmdline.cpp.obj
[487/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/common/random_manager.cpp.obj
[488/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/mac/mac_frame.cpp.obj
[489/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/mac/sub_mac.cpp.obj
[490/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/api/instance_api.cpp.obj
[491/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/common/uptime.cpp.obj
[492/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio.dir/thread/link_quality.cpp.obj
[493/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/api/logging_api.cpp.obj
[494/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/api/tasklet_api.cpp.obj
[495/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/diags/factory_diags.cpp.obj
[496/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/common/string.cpp.obj
[497/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/common/logging.cpp.obj
[498/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/crypto/aes_ecb.cpp.obj
[499/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/crypto/storage.cpp.obj
[500/712] Linking CXX static library lib/libopenthread-radio.a
[501/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/api/link_raw_api.cpp.obj
[502/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/common/instance.cpp.obj
[503/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/common/tasklet.cpp.obj
[504/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/crypto/aes_ccm.cpp.obj
[505/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/crypto/crypto_platform.cpp.obj
[506/712] Linking CXX static library lib/libopenthread-cli-radio.a
[507/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/common/timer.cpp.obj
[508/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/mac/mac_types.cpp.obj
[509/712] Building C object openthread/src/lib/platform/CMakeFiles/openthread-platform.dir/exit_code.c.obj
[510/712] Building CXX object openthread/src/lib/hdlc/CMakeFiles/openthread-hdlc.dir/hdlc.cpp.obj
[511/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/mac/link_raw.cpp.obj
[512/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/radio/radio_callbacks.cpp.obj
[513/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/mac/sub_mac_callbacks.cpp.obj
[514/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/utils/parse_cmdline.cpp.obj
[515/712] Linking CXX static library lib/libopenthread-hdlc.a
[516/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/radio/radio.cpp.obj
[517/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/radio/radio_platform.cpp.obj
[518/712] Linking C static library lib/libopenthread-platform.a
[519/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/thread/link_quality.cpp.obj
[520/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/mac/mac_frame.cpp.obj
[521/712] Building C object openthread/src/lib/spinel/CMakeFiles/openthread-spinel-ncp.dir/spinel.c.obj
[522/712] Building CXX object openthread/src/lib/spinel/CMakeFiles/openthread-spinel-ncp.dir/spinel_encoder.cpp.obj
[523/712] Building CXX object openthread/src/lib/spinel/CMakeFiles/openthread-spinel-ncp.dir/spinel_buffer.cpp.obj
[524/712] Building CXX object openthread/src/lib/spinel/CMakeFiles/openthread-spinel-ncp.dir/spinel_decoder.cpp.obj
[525/712] Building CXX object openthread/src/ncp/CMakeFiles/openthread-ncp-ftd.dir/changed_props_set.cpp.obj
[526/712] Building CXX object openthread/src/lib/spinel/CMakeFiles/openthread-spinel-rcp.dir/spinel_encoder.cpp.obj
[527/712] Building CXX object openthread/src/lib/spinel/CMakeFiles/openthread-spinel-rcp.dir/spinel_buffer.cpp.obj
[528/712] Building CXX object openthread/src/core/CMakeFiles/openthread-radio-cli.dir/mac/sub_mac.cpp.obj
[529/712] Building C object openthread/src/lib/spinel/CMakeFiles/openthread-spinel-rcp.dir/spinel.c.obj
[530/712] Building CXX object openthread/src/lib/spinel/CMakeFiles/openthread-spinel-rcp.dir/spinel_decoder.cpp.obj
[531/712] Linking CXX static library lib/libopenthread-spinel-ncp.a
[532/712] Building CXX object openthread/src/ncp/CMakeFiles/openthread-ncp-mtd.dir/changed_props_set.cpp.obj
[533/712] Linking CXX static library lib/libopenthread-radio-cli.a
[534/712] Linking CXX static library lib/libopenthread-spinel-rcp.a
[535/712] Building CXX object openthread/src/ncp/CMakeFiles/openthread-rcp.dir/changed_props_set.cpp.obj
[536/712] Building CXX object openthread/src/ncp/CMakeFiles/openthread-ncp-mtd.dir/ncp_base_radio.cpp.obj
[537/712] Building CXX object openthread/src/ncp/CMakeFiles/openthread-ncp-ftd.dir/ncp_spi.cpp.obj
[538/712] Building CXX object openthread/src/ncp/CMakeFiles/openthread-ncp-mtd.dir/ncp_base_ftd.cpp.obj
[539/712] Building CXX object openthread/src/ncp/CMakeFiles/openthread-rcp.dir/ncp_base_dispatcher.cpp.obj
[540/712] Building CXX object openthread/src/ncp/CMakeFiles/openthread-ncp-mtd.dir/ncp_hdlc.cpp.obj
[541/712] Building CXX object openthread/src/ncp/CMakeFiles/openthread-ncp-ftd.dir/ncp_base_dispatcher.cpp.obj
[542/712] Building CXX object openthread/src/ncp/CMakeFiles/openthread-ncp-mtd.dir/ncp_spi.cpp.obj
[543/712] Building CXX object openthread/src/ncp/CMakeFiles/openthread-ncp-ftd.dir/ncp_hdlc.cpp.obj
[544/712] Building CXX object openthread/src/ncp/CMakeFiles/openthread-ncp-mtd.dir/ncp_base_dispatcher.cpp.obj
[545/712] Building CXX object openthread/src/ncp/CMakeFiles/openthread-rcp.dir/ncp_base_radio.cpp.obj
[546/712] Building CXX object openthread/src/ncp/CMakeFiles/openthread-ncp-ftd.dir/ncp_base_ftd.cpp.obj
[547/712] Building C object openthread/third_party/tcplp/CMakeFiles/tcplp.dir/bsdtcp/cc/cc_newreno.c.obj
[548/712] Building C object openthread/third_party/tcplp/CMakeFiles/tcplp.dir/bsdtcp/tcp_reass.c.obj
[549/712] Building CXX object openthread/src/ncp/CMakeFiles/openthread-ncp-ftd.dir/ncp_base_radio.cpp.obj
[550/712] Building CXX object openthread/src/ncp/CMakeFiles/openthread-rcp.dir/ncp_spi.cpp.obj
[551/712] Building CXX object openthread/src/ncp/CMakeFiles/openthread-rcp.dir/ncp_base.cpp.obj
[552/712] Building C object openthread/third_party/tcplp/CMakeFiles/tcplp.dir/bsdtcp/tcp_timewait.c.obj
[553/712] Building CXX object openthread/src/ncp/CMakeFiles/openthread-ncp-ftd.dir/ncp_base.cpp.obj
[554/712] Building C object openthread/third_party/tcplp/CMakeFiles/tcplp.dir/lib/bitmap.c.obj
[555/712] Building C object openthread/third_party/tcplp/CMakeFiles/tcplp.dir/bsdtcp/tcp_sack.c.obj
[556/712] Building C object openthread/third_party/tcplp/CMakeFiles/tcplp.dir/bsdtcp/tcp_timer.c.obj
[557/712] Building CXX object openthread/src/ncp/CMakeFiles/openthread-ncp-mtd.dir/ncp_base.cpp.obj
[558/712] Building C object openthread/third_party/tcplp/CMakeFiles/tcplp.dir/bsdtcp/tcp_usrreq.c.obj
[559/712] Building C object openthread/third_party/tcplp/CMakeFiles/tcplp.dir/bsdtcp/tcp_output.c.obj
[560/712] Building C object openthread/third_party/tcplp/CMakeFiles/tcplp.dir/bsdtcp/tcp_subr.c.obj
[561/712] Building C object openthread/third_party/tcplp/CMakeFiles/tcplp.dir/lib/lbuf.c.obj
[562/712] Building C object openthread/third_party/tcplp/CMakeFiles/tcplp.dir/bsdtcp/tcp_input.c.obj
[563/712] Building C object openthread/third_party/tcplp/CMakeFiles/tcplp.dir/lib/cbuf.c.obj
[564/712] Building CXX object openthread/src/ncp/CMakeFiles/openthread-rcp.dir/ncp_hdlc.cpp.obj
[565/712] Building C object src/CMakeFiles/openthread-nrf52840-transport.dir/src/transport/transport.c.obj
[566/712] Building C object src/CMakeFiles/openthread-nrf52840.dir/src/logging.c.obj
[567/712] Building C object src/CMakeFiles/openthread-nrf52840.dir/src/flash.c.obj
[568/712] Building C object src/CMakeFiles/openthread-nrf52840.dir/src/misc.c.obj
[569/712] Building C object src/CMakeFiles/openthread-nrf52840.dir/src/entropy.c.obj
[570/712] Building C object src/CMakeFiles/openthread-nrf52840.dir/src/fem.c.obj
[571/712] Linking CXX static library lib/libopenthread-rcp.a
[572/712] Building C object src/CMakeFiles/openthread-nrf52840.dir/src/alarm.c.obj
[573/712] Linking CXX static library lib/libtcplp.a
[574/712] Building C object src/CMakeFiles/openthread-nrf52840.dir/src/diag.c.obj
[575/712] Building C object src/CMakeFiles/openthread-nrf52840.dir/src/system.c.obj
[576/712] Building CXX object openthread/src/ncp/CMakeFiles/openthread-ncp-mtd.dir/ncp_base_mtd.cpp.obj
[577/712] Building C object src/CMakeFiles/openthread-nrf52840.dir/src/temp.c.obj
[578/712] Building C object src/CMakeFiles/openthread-nrf52840.dir/src/flash_nosd.c.obj
[579/712] Building CXX object openthread/src/ncp/CMakeFiles/openthread-ncp-ftd.dir/ncp_base_mtd.cpp.obj
[580/712] Building C object src/CMakeFiles/openthread-nrf52840-transport.dir/src/transport/spi-slave.c.obj
[581/712] Building C object src/CMakeFiles/openthread-nrf52840-sdk.dir/src/logging.c.obj
[582/712] Building C object src/CMakeFiles/openthread-nrf52840-transport.dir/src/transport/uart.c.obj
[583/712] Building C object src/CMakeFiles/openthread-nrf52840-sdk.dir/src/misc.c.obj
[584/712] Building C object src/CMakeFiles/openthread-nrf52840.dir/src/radio.c.obj
[585/712] Building C object src/CMakeFiles/openthread-nrf52840-sdk.dir/src/fem.c.obj
[586/712] Building C object src/CMakeFiles/openthread-nrf52840-sdk.dir/src/entropy.c.obj
[587/712] Building C object src/CMakeFiles/openthread-nrf52840-sdk.dir/src/flash.c.obj
[588/712] Building C object src/CMakeFiles/openthread-nrf52840-sdk.dir/src/alarm.c.obj
[589/712] Building C object src/CMakeFiles/openthread-nrf52840-sdk.dir/src/system.c.obj
[590/712] Building C object src/CMakeFiles/openthread-nrf52840-sdk.dir/src/diag.c.obj
[591/712] Building C object src/CMakeFiles/openthread-nrf52840-transport.dir/src/transport/usb-cdc-uart.c.obj
[592/712] Building C object src/CMakeFiles/openthread-nrf52840-softdevice-sdk.dir/src/logging.c.obj
[593/712] Linking CXX static library lib/libopenthread-mtd.a
[594/712] Building C object src/CMakeFiles/openthread-nrf52840-sdk.dir/src/temp.c.obj
[595/712] Building C object src/CMakeFiles/openthread-nrf52840-sdk.dir/src/flash_nosd.c.obj
[596/712] Building C object src/CMakeFiles/openthread-nrf52840-softdevice-sdk.dir/src/temp.c.obj
[597/712] Building C object src/CMakeFiles/openthread-nrf52840-sdk.dir/src/radio.c.obj
[598/712] Building C object src/CMakeFiles/openthread-nrf52840-softdevice-sdk.dir/src/entropy.c.obj
[599/712] Building C object src/CMakeFiles/openthread-nrf52840-softdevice-sdk.dir/src/alarm.c.obj
[600/712] Building C object src/CMakeFiles/openthread-nrf52840-softdevice-sdk.dir/src/flash.c.obj
[601/712] Building C object src/CMakeFiles/openthread-nrf52840-softdevice-sdk.dir/src/fem.c.obj
[602/712] Building C object src/CMakeFiles/openthread-nrf52840-softdevice-sdk.dir/src/misc.c.obj
[603/712] Building C object src/CMakeFiles/openthread-nrf52840-softdevice-sdk.dir/src/diag.c.obj
[604/712] Building C object src/CMakeFiles/openthread-nrf52840-softdevice-sdk.dir/src/softdevice.c.obj
[605/712] Building C object src/CMakeFiles/openthread-nrf52840-softdevice-sdk.dir/src/flash_sd.c.obj
[606/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/dependencies/app_util_platform.c.obj
[607/712] Building C object src/CMakeFiles/openthread-nrf52840-softdevice-sdk.dir/src/system.c.obj
[608/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/libraries/app_error/app_error.c.obj
[609/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/libraries/utf_converter/utf.c.obj
[610/712] Building C object third_party/jlink/CMakeFiles/jlinkrtt.dir/SEGGER_RTT_V640/RTT/SEGGER_RTT.c.obj
[611/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/drivers/clock/nrf_drv_clock.c.obj
[612/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/libraries/app_error/app_error_weak.c.obj
[613/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/drivers/power/nrf_drv_power.c.obj
[614/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/nrfx/drivers/src/nrfx_clock.c.obj
[615/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/nrfx/drivers/src/nrfx_power.c.obj
[616/712] Linking C static library lib/libjlinkrtt.a
[617/712] Building C object src/CMakeFiles/openthread-nrf52840-softdevice-sdk.dir/src/radio.c.obj
[618/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/nrfx/hal/nrf_nvmc.c.obj
[619/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/nrfx/mdk/gcc_startup_nrf52840.S.obj
[620/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/nrfx/drivers/src/nrfx_systick.c.obj
[621/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/nrfx/drivers/src/nrfx_nvmc.c.obj
[622/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/libraries/atfifo/nrf_atfifo.c.obj
[623/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/libraries/atomic/nrf_atomic.c.obj
[624/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/nrfx/soc/nrfx_atomic.c.obj
[625/712] Linking CXX static library lib/libopenthread-ftd.a
[626/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/libraries/usb/app_usbd_serial_num.c.obj
[627/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/fal/nrf_802154_fal.c.obj
[628/712] Linking CXX static library lib/libopenthread-cli-ftd.a
[629/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/nrfx/drivers/src/nrfx_spis.c.obj
[630/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/libraries/usb/app_usbd_core.c.obj
[631/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/libraries/usb/app_usbd_string_desc.c.obj
[632/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/libraries/usb/app_usbd_nrf_dfu_trigger.c.obj
[633/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/nrfx/mdk/system_nrf52840.c.obj
[634/712] Linking CXX static library lib/libopenthread-cli-mtd.a
[635/712] Linking CXX static library lib/libopenthread-ncp-ftd.a
[636/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/libraries/usb/nrf_dfu_trigger_usb.c.obj
[637/712] Linking CXX static library lib/libopenthread-ncp-mtd.a
[638/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/mac_features/ack_generator/nrf_802154_ack_generator.c.obj
[639/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/mac_features/ack_generator/nrf_802154_imm_ack_generator.c.obj
[640/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/mac_features/ack_generator/nrf_802154_ack_data.c.obj
[641/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/mac_features/ack_generator/nrf_802154_enh_ack_generator.c.obj
[642/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/libraries/usb/app_usbd.c.obj
[643/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/libraries/usb/class/cdc/acm/app_usbd_cdc_acm.c.obj
[644/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/mac_features/nrf_802154_csma_ca.c.obj
[645/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/mac_features/nrf_802154_delayed_trx.c.obj
[646/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/nrf_802154_rssi.c.obj
[647/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-sdk.dir/nrfx/drivers/src/nrfx_usbd.c.obj
[648/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/mac_features/nrf_802154_filter.c.obj
[649/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/mac_features/nrf_802154_precise_ack_timeout.c.obj
[650/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/nrf_802154_core_hooks.c.obj
[651/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/nrf_802154_debug.c.obj
[652/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/mac_features/nrf_802154_frame_parser.c.obj
[653/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/nrf_802154_rx_buffer.c.obj
[654/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/fem/three_pin_gpio/nrf_fem_three_pin_gpio.c.obj
[655/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/nrf_802154_critical_section.c.obj
[656/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/nrf_802154_pib.c.obj
[657/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/platform/coex/nrf_802154_wifi_coex_none.c.obj
[658/712] Linking C static library lib/libnordicsemi-nrf52840-sdk.a
[659/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/nrf_802154_priority_drop_direct.c.obj
[660/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/rsch/nrf_802154_rsch_crit_sect.c.obj
[661/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/nrf_802154_timer_coord.c.obj
[662/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/nrf_802154.c.obj
[663/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/rsch/nrf_802154_rsch.c.obj
[664/712] Linking C static library lib/libopenthread-nrf52840-transport.a
[665/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/platform/clock/nrf_802154_clock_ot.c.obj
[666/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/timer_scheduler/nrf_802154_timer_sched.c.obj
[667/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/rsch/raal/single_phy/single_phy.c.obj
[668/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/fal/nrf_802154_fal.c.obj
[669/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/platform/hp_timer/nrf_802154_hp_timer.c.obj
[670/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/nrf_802154_notification_direct.c.obj
[671/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/nrf_802154_request_direct.c.obj
[672/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/mac_features/ack_generator/nrf_802154_ack_generator.c.obj
[673/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/mac_features/ack_generator/nrf_802154_ack_data.c.obj
[674/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/nrf_802154_core_hooks.c.obj
[675/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/mac_features/ack_generator/nrf_802154_imm_ack_generator.c.obj
[676/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/mac_features/ack_generator/nrf_802154_enh_ack_generator.c.obj
[677/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver.dir/drivers/radio/nrf_802154_core.c.obj
[678/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/nrf_802154_rssi.c.obj
[679/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/mac_features/nrf_802154_filter.c.obj
[680/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/mac_features/nrf_802154_precise_ack_timeout.c.obj
[681/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/mac_features/nrf_802154_csma_ca.c.obj
[682/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/mac_features/nrf_802154_frame_parser.c.obj
[683/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/fem/three_pin_gpio/nrf_fem_three_pin_gpio.c.obj
[684/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/platform/coex/nrf_802154_wifi_coex_none.c.obj
[685/712] Linking C static library lib/libnordicsemi-nrf52840-radio-driver.a
[686/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/mac_features/nrf_802154_delayed_trx.c.obj
[687/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/nrf_802154_debug.c.obj
[688/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/nrf_802154_rx_buffer.c.obj
[689/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/nrf_802154_priority_drop_direct.c.obj
[690/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/nrf_802154_critical_section.c.obj
[691/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/rsch/nrf_802154_rsch_crit_sect.c.obj
[692/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/rsch/raal/single_phy/single_phy.c.obj
[693/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/platform/clock/nrf_802154_clock_ot.c.obj
[694/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/nrf_802154_timer_coord.c.obj
[695/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/nrf_802154_pib.c.obj
[696/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/timer_scheduler/nrf_802154_timer_sched.c.obj
[697/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/rsch/nrf_802154_rsch.c.obj
[698/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/platform/hp_timer/nrf_802154_hp_timer.c.obj
[699/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/nrf_802154.c.obj
[700/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/nrf_802154_core.c.obj
[701/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/nrf_802154_notification_direct.c.obj
[702/712] Building C object third_party/NordicSemiconductor/CMakeFiles/nordicsemi-nrf52840-radio-driver-softdevice.dir/drivers/radio/nrf_802154_request_direct.c.obj
[703/712] Linking C static library lib/libnordicsemi-nrf52840-radio-driver-softdevice.a
[704/712] Linking CXX static library lib/libopenthread-nrf52840-sdk.a
[705/712] Linking CXX static library lib/libopenthread-nrf52840.a
[706/712] Linking CXX static library lib/libopenthread-nrf52840-softdevice-sdk.a
[707/712] Linking CXX executable bin/ot-cli-radio
[708/712] Linking CXX executable bin/ot-rcp
[709/712] Linking CXX executable bin/ot-ncp-mtd
[710/712] Linking CXX executable bin/ot-cli-mtd
[711/712] Linking CXX executable bin/ot-ncp-ftd
[712/712] Linking CXX executable bin/ot-cli-ftd
+ cd /workdir/project
```