### PR TITLE
[usb] add usbd event processing trigger when flush function is called

### DIFF
--- a/src/src/transport/usb-cdc-uart.c
+++ b/src/src/transport/usb-cdc-uart.c
@@ -343,8 +343,10 @@ otError otPlatUartDisable(void)
 otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 {
     otError error = OT_ERROR_NONE;
-
-    otEXPECT_ACTION(sUsbState.mTransferInProgress == false, error = OT_ERROR_BUSY);
+    if (sUsbState.mTransferInProgress == true)
+    {
+        otPlatUartFlush();
+    }
     otEXPECT_ACTION(sUsbState.mTxBuffer == NULL, error = OT_ERROR_BUSY);
 
     if (!isPortOpened())
@@ -369,6 +371,11 @@ otError otPlatUartFlush(void)
     while (sUsbState.mTransferInProgress && !sUsbState.mTransferDone)
     {
         // Wait until the transmission is done
+        while (app_usbd_event_queue_process())
+        {
+        }
+        processConnection();
+        processTransmit();
     }
 
     processTransmit();


### PR DESCRIPTION
This commit adds triggering events on usbd while waiting for end of
cdc uart transmission. aLso ensures that tx buffers aren't modified when
transmission is ongoing.

addresses #237 
