### PR TITLE
[crypto] add crypto platform API

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,7 @@ endif()
 
 set(NRF_COMM_SOURCES
     src/alarm.c
+    src/crypto.c
     src/diag.c
     src/entropy.c
     src/fem.c

--- a/src/src/crypto.c
+++ b/src/src/crypto.c
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (c) 2022, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *    This file implements the Crypto platform APIs.
+ */
+
+#include <openthread/platform/crypto.h>
+
+#include <openthread-core-config.h>
+#include <openthread/config.h>
+
+#include <assert.h>
+
+#include "platform-nrf5.h"
+
+#include <hal/nrf_ecb.h>
+
+void nrf5CryptoInit(void)
+{
+    // Intentionally empty.
+    // This function is used to force the linker to link the the Crypto platform APIs implemented in this file,
+    // Otherwise, the linker links the weak Crypto platform APIs implemented in `crypto_platform.cpp`.
+}
+
+otError otPlatCryptoAesInit(otCryptoContext *aContext)
+{
+    OT_UNUSED_VARIABLE(aContext);
+
+    nrf_ecb_init();
+
+    return OT_ERROR_NONE;
+}
+
+otError otPlatCryptoAesSetKey(otCryptoContext *aContext, const otCryptoKey *aKey)
+{
+    OT_UNUSED_VARIABLE(aContext);
+
+    assert(aKey->mKey != NULL);
+    assert(aKey->mKeyLength == 16);
+
+    nrf_ecb_set_key(aKey->mKey);
+
+    return OT_ERROR_NONE;
+}
+
+otError otPlatCryptoAesEncrypt(otCryptoContext *aContext, const uint8_t *aInput, uint8_t *aOutput)
+{
+    return nrf_ecb_crypt(aOutput, aInput) ? OT_ERROR_NONE : OT_ERROR_FAILED;
+}
+
+otError otPlatCryptoAesFree(otCryptoContext *aContext)
+{
+    OT_UNUSED_VARIABLE(aContext);
+    return OT_ERROR_NONE;
+}

--- a/src/src/platform-nrf5.h
+++ b/src/src/platform-nrf5.h
@@ -164,6 +164,12 @@ otError nrf5FlashWrite(uint32_t aAddress, const uint8_t *aData, uint32_t aSize);
 void nrf5TempInit(void);
 
 /**
+ * Initialization of crypto module.
+ *
+ */
+void nrf5CryptoInit(void);
+
+/**
  * Deinitialization of temperature controller.
  *
  */

--- a/src/src/system.c
+++ b/src/src/system.c
@@ -103,6 +103,7 @@ void otSysInit(int argc, char *argv[])
     nrf5RadioInit();
     nrf5TempInit();
     nrf5FemInit();
+    nrf5CryptoInit();
 
     gPlatformPseudoResetWasRequested = false;
 }

--- a/third_party/NordicSemiconductor/CMakeLists.txt
+++ b/third_party/NordicSemiconductor/CMakeLists.txt
@@ -94,6 +94,7 @@ set(COMMON_SOURCES
     nrfx/drivers/src/nrfx_power.c
     nrfx/drivers/src/nrfx_spis.c
     nrfx/drivers/src/nrfx_systick.c
+    nrfx/hal/nrf_ecb.c
     nrfx/hal/nrf_nvmc.c
     nrfx/soc/nrfx_atomic.c
 )


### PR DESCRIPTION
The radio driver calls the `nrf_802154_tx_started` after the `SFD` is
sent. The radio driver must complete the encryption of the first byte
of the payload before it is sent in the function `nrf_802154_tx_started`.
The chip nrf52811 is using the software AES ECB encryption, the
encryption speed is slow. Sometimes, it causes the first received payload
byte is not encrypted.

This PR uses the ECB hardware to implement the crypto platform API
to improve the encryption speed.