### PR TITLE
[crypto] fix ECB module assertion under heavy traffic

### DIFF
--- a/src/src/platform-nrf5.h
+++ b/src/src/platform-nrf5.h
@@ -164,12 +164,6 @@ otError nrf5FlashWrite(uint32_t aAddress, const uint8_t *aData, uint32_t aSize);
 void nrf5TempInit(void);
 
 /**
- * Initialization of crypto module.
- *
- */
-void nrf5CryptoInit(void);
-
-/**
  * Deinitialization of temperature controller.
  *
  */


### PR DESCRIPTION
After #369 introduced the usage of the ECB peripheral, `AesEcb::Encrypt`
would assert under heavy traffic situation in FTD mode due to the
counter reaching 0 value in `nrf_ecb_crypt`.

Reproduction has a 100% rate when using `tcp benchmark` command when
the device is configured as TCP listener.

This commit disables interrupts while ECB encryption is taking place.
It also removes duplicated declaration of `nrf5CryptoInit`.