### PR TITLE
[alarm] prioritize usec timer over msec

### DIFF
--- a/src/src/alarm.c
+++ b/src/src/alarm.c
@@ -493,6 +493,13 @@ void nrf5AlarmProcess(otInstance *aInstance)
     {
         sEventPending = false;
 
+        if (sTimerData[kUsTimer].mFireAlarm)
+        {
+            sTimerData[kUsTimer].mFireAlarm = false;
+
+            otPlatAlarmMicroFired(aInstance);
+        }
+
         if (sTimerData[kMsTimer].mFireAlarm)
         {
             sTimerData[kMsTimer].mFireAlarm = false;
@@ -510,12 +517,6 @@ void nrf5AlarmProcess(otInstance *aInstance)
             }
         }
 
-        if (sTimerData[kUsTimer].mFireAlarm)
-        {
-            sTimerData[kUsTimer].mFireAlarm = false;
-
-            otPlatAlarmMicroFired(aInstance);
-        }
     } while (sEventPending);
 }
 


### PR DESCRIPTION
This commit prioritizes usec timer over msec. Doing so improves CSL by helping scheduling timeslots on IEEE 802.15.4 with lower miss rate.

Signed-off-by: Przemyslaw Bida <przemyslaw.bida@nordicsemi.no>