### PR TITLE
[link-metrics] add missing initialization of noisefloor for link metrics

### DIFF
--- a/src/src/radio.c
+++ b/src/src/radio.c
@@ -359,6 +359,9 @@ void otPlatRadioSetShortAddress(otInstance *aInstance, uint16_t aShortAddress)
 void nrf5RadioInit(void)
 {
     dataInit();
+#if OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
+    otLinkMetricsInit(NRF528XX_RECEIVE_SENSITIVITY);
+#endif
     nrf_802154_init();
 }
 


### PR DESCRIPTION
The PR adds missing initialization of noise floor in link metrics
module. Without the PR, the link margin obtained in link metrics
enhanced-ack probing is incorrect.

On simulation platform, the initialization is done:
https://github.com/openthread/openthread/blob/main/examples/platforms/simulation/radio.c#L503