### PR TITLE
[radio] fix csl uncertainty reporting max value

### DIFF
--- a/src/src/radio.c
+++ b/src/src/radio.c
@@ -1416,7 +1416,7 @@ uint8_t otPlatRadioGetCslAccuracy(otInstance *aInstance)
     return otPlatTimeGetXtalAccuracy() / 2;
 }
 
-uint8_t otPlatRadioGetCslClockUncertainty(otInstance *aInstance)
+uint8_t otPlatRadioGetCslUncertainty(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);
 


### PR DESCRIPTION
The function to query the csl uncertainty has an incorrect name in the nrf code `otPlatRadioGetCslClockUncertainty` as opposed to `otPlatRadioGetCslUncertainty`. See https://github.com/openthread/openthread/blob/main/include/openthread/platform/radio.h#L1212 .

Since openthread has a default weak implementation of the function this doesn't cause any linker errors but instead silently uses 255 which effectively increases the CSL window by a constant 10ms.