### PR TITLE
[radio] add `mInfo.mTxInfo.mMaxCsmaBackoffs` support

### DIFF
--- a/src/src/radio.c
+++ b/src/src/radio.c
@@ -557,6 +557,7 @@ otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aFrame)
 
         if (aFrame->mInfo.mTxInfo.mCsmaCaEnabled)
         {
+            nrf_802154_max_num_csma_ca_backoffs_set(aFrame->mInfo.mTxInfo.mMaxCsmaBackoffs);
             nrf_802154_transmit_csma_ca_raw(&aFrame->mPsdu[-1]);
         }
         else

--- a/third_party/NordicSemiconductor/drivers/radio/mac_features/nrf_802154_csma_ca.h
+++ b/third_party/NordicSemiconductor/drivers/radio/mac_features/nrf_802154_csma_ca.h
@@ -45,6 +45,15 @@
  */
 
 /**
+ * @brief Sets the maximum number of backoffs that the CSMA-CA algorithm will attempt before declaring a channel access failure.
+ *
+ * @note If the @p max_num_nb is set to 0, the backoff mechanism will be skipped and the CCA will still be performed once.
+ *
+ * @param[in]  max_num_nb  The maximum number of CSMA-CA backoffs.
+ */
+void nrf_802154_csma_ca_max_num_csma_ca_backoffs_set(uint8_t max_num_nb);
+
+/**
  * @brief Starts the CSMA-CA procedure for the transmission of a given frame.
  *
  * If the CSMA-CA procedure is successful and the frame is transmitted,

--- a/third_party/NordicSemiconductor/drivers/radio/nrf_802154.c
+++ b/third_party/NordicSemiconductor/drivers/radio/nrf_802154.c
@@ -661,6 +661,11 @@ void nrf_802154_cca_cfg_get(nrf_802154_cca_cfg_t * p_cca_cfg)
 }
 
 #if NRF_802154_CSMA_CA_ENABLED
+void nrf_802154_max_num_csma_ca_backoffs_set(uint8_t max_num_nb)
+{
+    nrf_802154_csma_ca_max_num_csma_ca_backoffs_set(max_num_nb);
+}
+
 #if NRF_802154_USE_RAW_API
 
 void nrf_802154_transmit_csma_ca_raw(const uint8_t * p_data)

--- a/third_party/NordicSemiconductor/drivers/radio/nrf_802154.h
+++ b/third_party/NordicSemiconductor/drivers/radio/nrf_802154.h
@@ -1174,6 +1174,16 @@ void nrf_802154_cca_cfg_get(nrf_802154_cca_cfg_t * p_cca_cfg);
  * @{
  */
 #if NRF_802154_CSMA_CA_ENABLED
+
+/**
+ * @brief Sets the maximum number of backoffs that the CSMA-CA algorithm will attempt before declaring a channel access failure.
+ *
+ * @note If the @p max_num_nb is set to 0, the backoff mechanism will be skipped and the CCA will still be performed once.
+ *
+ * @param[in]  max_num_nb  The maximum number of CSMA-CA backoffs.
+ */
+void nrf_802154_max_num_csma_ca_backoffs_set(uint8_t max_num_nb);
+
 #if NRF_802154_USE_RAW_API
 
 /**


### PR DESCRIPTION
The current radio driver doesn't handle the `mInfo.mTxInfo.mMaxCsmaBackoffs` field of the tx frame. The maximum number of CSMA-CA backoffs is set to the fixed value `4`.

This commit sets the maximum number of CSMA-CA backoffs to `mInfo.mTxInfo.mMaxCsmaBackoffs`.