### PR TITLE
[radio] correct the `mInfo.mRxInfo.mTimestamp` value of recevied frames

### DIFF
--- a/src/src/radio.c
+++ b/src/src/radio.c
@@ -1037,9 +1037,7 @@ void nrf_802154_received_timestamp_raw(uint8_t *p_data, int8_t power, uint8_t lq
 #if !NRF_802154_TX_STARTED_NOTIFY_ENABLED
 #error "NRF_802154_TX_STARTED_NOTIFY_ENABLED is required!"
 #endif
-    uint32_t offset =
-        (int32_t)otPlatAlarmMicroGetNow() - (int32_t)nrf_802154_first_symbol_timestamp_get(time, p_data[0]);
-    receivedFrame->mInfo.mRxInfo.mTimestamp = nrf5AlarmGetCurrentTime() - offset;
+    receivedFrame->mInfo.mRxInfo.mTimestamp = nrf_802154_timestamp_end_to_phr_convert(time, p_data[0]);
 
     sAckedWithFramePending = false;
 
@@ -1172,10 +1170,7 @@ void nrf_802154_transmitted_timestamp_raw(const uint8_t *aFrame,
     }
     else
     {
-        uint32_t offset =
-            (int32_t)otPlatAlarmMicroGetNow() - (int32_t)nrf_802154_first_symbol_timestamp_get(ack_time, aAckPsdu[0]);
-
-        sAckFrame.mInfo.mRxInfo.mTimestamp = nrf5AlarmGetCurrentTime() - offset;
+        sAckFrame.mInfo.mRxInfo.mTimestamp = nrf_802154_timestamp_end_to_phr_convert(ack_time, aAckPsdu[0]);
         sAckFrame.mPsdu                    = &aAckPsdu[1];
         sAckFrame.mLength                  = aAckPsdu[0];
         sAckFrame.mInfo.mRxInfo.mRssi      = aPower;

--- a/third_party/NordicSemiconductor/drivers/radio/nrf_802154.c
+++ b/third_party/NordicSemiconductor/drivers/radio/nrf_802154.c
@@ -200,6 +200,13 @@ uint32_t nrf_802154_first_symbol_timestamp_get(uint32_t end_timestamp, uint8_t p
     return end_timestamp - (frame_symbols * PHY_US_PER_SYMBOL);
 }
 
+uint64_t nrf_802154_timestamp_end_to_phr_convert(uint64_t end_timestamp, uint8_t psdu_length)
+{
+    uint32_t frame_symbols = (PHR_SIZE + psdu_length) * PHY_SYMBOLS_PER_OCTET;
+
+    return end_timestamp - (frame_symbols * PHY_US_PER_SYMBOL);
+}
+
 void nrf_802154_init(void)
 {
     nrf_802154_ack_data_init();

--- a/third_party/NordicSemiconductor/drivers/radio/nrf_802154.h
+++ b/third_party/NordicSemiconductor/drivers/radio/nrf_802154.h
@@ -245,6 +245,21 @@ uint8_t nrf_802154_ccaedthres_from_dbm_calculate(int8_t dbm);
 uint32_t nrf_802154_first_symbol_timestamp_get(uint32_t end_timestamp, uint8_t psdu_length);
 
 /**
+ * @brief  Converts the timestamp of the frame's end to the timestamp of the start of its PHR.
+ *
+ * This function calculates the time when the first symbol of the PHR is at the local antenna. Note
+ * that this time is equivalent to the end of the frame's SFD and RMARKER as defined in'
+ * IEEE 802.15.4-2020, Section 6.9.1.
+ *
+ * @param[in]  end_timestamp  Timestamp of the end of the last symbol in the frame,
+ *                            in microseconds.
+ * @param[in]  psdu_length    Number of bytes in the frame PSDU.
+ *
+ * @return  Timestamp of the start of the PHR of a given frame, in microseconds.
+ */
+uint64_t nrf_802154_timestamp_end_to_phr_convert(uint64_t end_timestamp, uint8_t psdu_length);
+
+/**
  * @}
  * @defgroup nrf_802154_transitions Functions to request FSM transitions and check current state
  * @{


### PR DESCRIPTION
The `mInfo.mRxInfo.mTimestamp` represents the end time of the SFD of the received frame. But the radio driver sets the `mInfo.mRxInfo.mTimestamp` value to the first symbol time of the received frame.

This commit adds a method `nrf_802154_timestamp_end_to_phr_convert()` to calculate the end time of the SFD of the received frame. The method comes from the `sdk-nrfxlib`.