### PR TITLE
[radio] use correct csl accuracy and uncertainty values when the CSL transmitter is enabled

### DIFF
--- a/src/src/radio.c
+++ b/src/src/radio.c
@@ -1413,7 +1413,9 @@ void otPlatRadioUpdateCslSampleTime(otInstance *aInstance, uint32_t aCslSampleTi
 
     sCslSampleTime = aCslSampleTime;
 }
+#endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
 uint8_t otPlatRadioGetCslAccuracy(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);
@@ -1427,8 +1429,7 @@ uint8_t otPlatRadioGetCslUncertainty(otInstance *aInstance)
 
     return CSL_UNCERT;
 }
-
-#endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+#endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
 
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
 otError otPlatRadioConfigureEnhAckProbing(otInstance          *aInstance,


### PR DESCRIPTION
The CSL transmitter is using the OT defined default CSL accuracy and uncertainty values. 

This commit enables `otPlatRadioGetCslAccuracy()` and `otPlatRadioGetCslUncertainty()`  when the CSL transmitter is enabled to make the CSL transmitter to use correct CSL accuracy and uncertainty values.