### PR TITLE
[radio] fix Key Index matching at rotation boundaries

### DIFF
--- a/src/src/radio.c
+++ b/src/src/radio.c
@@ -281,6 +281,8 @@ static void txAckProcessSecurity(uint8_t *aAckFrame)
     otRadioFrame      ackFrame;
     otMacKeyMaterial *key = NULL;
     uint8_t           keyId;
+    uint8_t           keyIndex;
+    uint8_t           currKeyIndex;
 
     sAckedWithSecEnhAck = false;
     otEXPECT(aAckFrame[SECURITY_ENABLED_OFFSET] & SECURITY_ENABLED_BIT);
@@ -292,18 +294,22 @@ static void txAckProcessSecurity(uint8_t *aAckFrame)
     keyId = otMacFrameGetKeyId(&ackFrame);
 
     otEXPECT(otMacFrameIsKeyIdMode1(&ackFrame) && keyId != 0);
+    otEXPECT(sKeyId != 0);
 
-    if (keyId == sKeyId)
+    keyIndex     = keyId - 1;
+    currKeyIndex = sKeyId - 1;
+
+    if (keyIndex == currKeyIndex)
     {
         key              = &sCurrKey;
         sAckFrameCounter = sMacFrameCounter++;
     }
-    else if (keyId == sKeyId - 1)
+    else if (keyIndex == ((currKeyIndex + 127U) & 0x7fU))
     {
         key              = &sPrevKey;
         sAckFrameCounter = sPrevMacFrameCounter++;
     }
-    else if (keyId == sKeyId + 1)
+    else if (keyIndex == ((currKeyIndex + 1U) & 0x7fU))
     {
         key = &sNextKey;
         // Openthread does not maintain future frame counter.


### PR DESCRIPTION
Per Thread Specification (Section 7.1.5 Key Index), Key Index Mode 1 is calculated as (keySequence & 0x7f) + 1. The resulting Key Index cycles from 1 to 128 and wraps back to 1.

The previous logic in txAckProcessSecurity() checked sKeyId - 1 and sKeyId + 1 directly. This failed at key rotation boundaries (128 -> 1 and 1 -> 128) because 1 - 1 = 0 (instead of 128) and 128 + 1 = 129 (instead of 1).

This commit updates txAckProcessSecurity() to convert keyId and sKeyId to 0-based indices and mask with 0x7f, properly handling key index wraparound at rotation boundaries.

Fixes #1313