### PR TITLE
[github-actions] fix zizmor security findings in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,9 @@
 
 name: Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches-ignore:
@@ -48,6 +51,7 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         submodules: recursive
+        persist-credentials: false
     - name: Bootstrap
       run: |
         sudo apt-get update
@@ -83,6 +87,7 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         submodules: recursive
+        persist-credentials: false
     - name: Bootstrap
       run: |
         cd /tmp


### PR DESCRIPTION
This commit fixes GitHub Actions zizmor security scanner findings in build.yml.

Zizmor flagged the following issues in build.yml:
- Missing top-level permissions block (excessive-permissions).
- Default credential persistence on checkout steps (artipacked).

This change resolves the zizmor findings by:
- Adding top-level permissions: contents: read.
- Setting persist-credentials: false on checkout steps.